### PR TITLE
Add a listener to set renderer and camera size when screen resizes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -33,6 +33,24 @@ renderer.setSize(
 document.body.appendChild(renderer.domElement)
 
 
+//////////////////////////////////////////////
+// Change renderer size and camera ratio by maintaining the perspective when screen is resized
+window.addEventListener('resize', () => {
+  const width = window.innerWidth
+  const height = window.innerHeight
+
+  //set the camera aspect ratio
+  camera.aspect = width / height
+  //updates the perspective
+  camera.updateProjectionMatrix()
+
+  //set the renderer size
+  renderer.setSize(
+    width,
+    height
+  )
+})
+
 
 //////////////////////////////////////////////
 // Adding a cube geometry


### PR DESCRIPTION
Add a listener to set renderer width and height and camera aspect ratio after screen resizes by using an event listener and the proper methods